### PR TITLE
fix: correct response when it is plain text

### DIFF
--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -272,7 +272,11 @@ function Invoke-MetasysMethod {
         if ($responseObject) {
 
             $contentLength = 0
-            [Int]::TryParse($responseObject.Headers["Content-Length"], [ref] $contentLength)  | Out-Null
+            if ($responseObject.Headers["Content-Length"]) {
+                [Int]::TryParse($responseObject.Headers["Content-Length"], [ref] $contentLength)  | Out-Null
+            } elseif ($responseObject.Content -is [String]) {
+                $contentLength = $responseObject.Content
+            }
 
             if ($responseObject.Headers["Content-Type"] -like "*json*" -or $contentLength -eq 0 -or $responseObject.StatusCode -eq 204 -or $responseObject.StatusCode -ge 400) {
                 $contentType = "json"
@@ -317,10 +321,10 @@ function Invoke-MetasysMethod {
             if ($contentType -eq "text") {
 
                 if ($IncludeResponseHeaders) {
-                    convertResponseObjectToString $responseObject
+                    $responseObject.RawContent
                 }
                 else {
-                    $responseObject.Content
+                    $response
                 }
             }
 

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -53,11 +53,19 @@ class MetasysEnvVars {
     }
 
     static [string] getLast() {
-        return $env:METASYS_LAST_RESPONSE
+        if ($env:METASYS_LAST_RESPONSE_PATH) {
+            return [System.IO.File]::ReadAllText($env:METASYS_LAST_RESPONSE_PATH)
+        }
+        return ""
     }
 
     static [void] setLast([string]$last) {
-        $env:METASYS_LAST_RESPONSE = $last
+        # This variable used to save the last response to an env var, but that generally can be very large
+        # So now instead we write the response to a temp file and instead of writing to
+        # $env:METASYS_LAST_RESPONSE we write the path of the file to $env:METASYS_LAST_RESPONSE_PATH
+        $tempFile = New-TemporaryFile
+        Set-Content -Path $tempFile.FullName -Value $last
+        $env:METASYS_LAST_RESPONSE_PATH = $tempFile.FullName
     }
 
     static [void] clear() {


### PR DESCRIPTION
### fix: correct response when it is plain text

There were some scenarios where a plain text file was returned but the
Content-Length header was not set. The internal logic just defaults the
Content-Type to "json" when there is no Content-Length. This commit
fixes this bug.

The symptom of this bug is that the plain text file would be embedded within
another string. Meaning the output of the call would have double quotes around
it and all line feeds in the content would be escaped. This is now resolved.

### fix: use temp files for saving responses

This program used to save the responses from `imm` in
`$env:METASYS_LAST_RESPONSE`.
But in general responses can be large and session errors can happen
when the total length of env variable characters is greater than 32,767.

So this commit now writes the last result to a temp file and stores the path
to that temp file in $env:METASYS_LAST_RESPONSE_PATH